### PR TITLE
Make the Exploit model more flexible to data with interface{} instead of json.Number in multiple fields closes #9

### DIFF
--- a/models/exploit.go
+++ b/models/exploit.go
@@ -1,7 +1,5 @@
 package models
 
-//import "encoding/json"
-
 type Exploit struct {
 	// Unique ID for the exploit/vulnerability
 	Id interface{} `json:"_id"`

--- a/models/exploit.go
+++ b/models/exploit.go
@@ -1,16 +1,16 @@
 package models
 
-import "encoding/json"
+//import "encoding/json"
 
 type Exploit struct {
 	// Unique ID for the exploit/vulnerability
-	Id json.Number `json:"_id"`
+	Id interface{} `json:"_id"`
 
 	// The author of the exploit/vulnerability.
 	Author interface{} `json:"author"`
 
 	// The Bugtraq ID for the exploit.
-	BID []json.Number `json:"bid"`
+	BID interface{} `json:"bid"`
 
 	// The actual code of the exploit.
 	Code string `json:"code"`
@@ -28,10 +28,10 @@ type Exploit struct {
 	Source string `json:"source"`
 
 	// The Microsoft Security Bulletin ID for the exploit.
-	MSB []json.Number `json:"msb"`
+	MSB interface{} `json:"msb"`
 
 	// The Open Source Vulnerability Database ID for the exploit.
-	OSVDB []json.Number `json:"osvdb"`
+	OSVDB interface{} `json:"osvdb"`
 
 	// The operating system that the exploit targets. Possible values are: aix, cgi, freebsd, hardware, Java, jsp,
 	// lin_x86, Linux, multiple, novell, osx, PHP, true64, Unix, Windows
@@ -51,5 +51,5 @@ type Exploit struct {
 	Rank       interface{} `json:"rank"`
 	Arch       interface{} `json:"arch"`
 	Privileged bool        `json:"privileged"`
-	Version    json.Number `json:"version"`
+	Version    interface{} `json:"version"`
 }


### PR DESCRIPTION
This is a simple solution, making the handler more flexible to the weird and wonderful formats it receives.

This works for our needs, and may help others - but I'm open to other more specific solutions if preferred.