### PR TITLE
"Region" Query property has the wrong type. It Should be a string

### DIFF
--- a/search/query.go
+++ b/search/query.go
@@ -97,7 +97,7 @@ type Query struct {
 	HasVuln bool `shodan_search:"has_vuln"`
 
 	// Region code
-	Region int `shodan_search:"region"`
+	Region string `shodan_search:"region"`
 
 	// Host tag. Enterprise only.
 	Tag string `shodan_search:"tag"`


### PR DESCRIPTION
Hi Anton,

It seems as if the field "Region" in "query.go"  should be a string not an int

The region property returned from Shodan is a string abbreviation and when querying shodan directly the desired results for region seem to be returned using the same abbreviations

Thanks 